### PR TITLE
Update main

### DIFF
--- a/main
+++ b/main
@@ -12,7 +12,11 @@ echo "converting pial and white matter surfaces"
 
 mkdir surfaces
 
-time singularity exec -e docker://brainlife/freesurfer:6.0.0 bash -c "echo $FREESURFER_LICENSE > /usr/local/freesurfer/license.txt && ./convertfiles.sh"
+[ -z "$FREESURFER_LICENSE" ] && echo "Please set FREESURFER_LICENSE in .bashrc" && exit 1;
+echo $FREESURFER_LICENSE > license.txt
+
+time singularity exec -e -B `pwd`/license.txt:/usr/local/freesurfer/license.txt \
+        docker://brainlife/freesurfer_on_mcr:6.0.2 ./convertfiles.sh
 
 count=$(ls surfaces/* | wc -l)
 


### PR DESCRIPTION
The new version of singularity no longer allows us to inject freesurfer license directly to the container. Please update it to this so that this App will run again.

[34mINFO:   [0m Creating SIF file...
[33mWARNING:[0m skipping mount of /N/project: permission denied
[31mFATAL:  [0m container creation failed: mount /N/project->/N/project error: while mounting /N/project: while getting stat for /N/project: stat /N/project: permission denied